### PR TITLE
Fix #4: Enforce standard double quotes and support spaces in string literals

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5,32 +5,57 @@
 #include<algorithm>
 
 //tokenize select query for processing
+//tokenize select query for processing
 void tokenize_select(char query[]){
-    char buffer[1024];
-    vector <string> token_vector;
-    
-    strcpy(buffer, query);
-    
-    // Uses standard strtok, splitting strictly on spaces, commas, semicolons, and newlines
-    char *token = strtok(buffer, " ,;\n"); 
-    
-    while (token) {
-        string token_temp(token);
-        if(token_temp != " " && token_temp != "\n" ){
-            token_vector.push_back(token_temp);
+    vector<string> token_vector;
+    string current_token = "";
+    bool in_quotes = false;
+
+    for(int i = 0; query[i] != '\0'; i++){
+        char c = query[i];
+
+        // If we hit a quote, toggle our "inside quotes" state and add the quote to the token
+        if(c == '"'){
+            in_quotes = !in_quotes;
+            current_token += c; 
         }
-        token = strtok(NULL, " ,;\n"); 
+        // If we are NOT in quotes, treat spaces, commas, semicolons, and newlines as split points
+        else if(!in_quotes && (c == ' ' || c == ',' || c == ';' || c == '\n')){
+            if(!current_token.empty()){
+                token_vector.push_back(current_token);
+                current_token = "";
+            }
+        }
+        // Otherwise, just keep building the current word
+        else {
+            if(c != '\n') {
+                current_token += c;
+            }
+        }
     }
+    
+    // Catch the very last token if the string ended
+    if(!current_token.empty()){
+        token_vector.push_back(current_token);
+    }
+
     process_select(token_vector);
 }
 
 //tokenize create query for processing
 void tokenize_create(char query[]){
+    // CREATE TABLE [IF NOT EXISTS] <tablename> (<column1> <datatype>, <column2> <datatype>, PRIMARY KEY(<column1>));
+
+    /*
+    * implementation1
+    CREATE TABLE <tablename> (<column1> <datatype>, <column2> <datatype>);
+    */
     char buffer[1024];
     vector <string> token_vector;
 
     strcpy(buffer, query);
     
+    // FIX: Added \n here as well so CREATE queries don't suffer from the same newline bug
     char *token = strtok(buffer, " ,;\n");
     while (token) {
         string token_temp(token);
@@ -40,6 +65,10 @@ void tokenize_create(char query[]){
         }
         token = strtok(NULL, " ,;\n");
     }
+
+    // for(int i=0;i<token_vector.size();i++){
+    //     cout<<token_vector[i]<<endl;
+    // }
     cout<<endl;
 }
 
@@ -52,13 +81,16 @@ void get_query(){
     fgets(query,sizeof(char)*MAX_NAME,stdin);
     fgets(query,sizeof(char)*MAX_NAME,stdin);
 
+    //
     char buffer[1024];
     strcpy(buffer, query);
     
+    // FIX: Added \n here to ensure the first command word is caught cleanly
     char *token = strtok(buffer, " \n");
     if(token){
         string token_temp(token);
         if(token_temp != " " && token_temp != "\n"){
+            //cout<<"token:: "<<token<<endl;
             if(token_temp == "select"){
                 tokenize_select(query);
             }else if(token_temp == "create"){
@@ -66,6 +98,9 @@ void get_query(){
             }
         }
     }
+
+
+    //printf("\nquery:: %s\n",query);
 }
 
 void parse_create(){
@@ -79,4 +114,5 @@ void parse_create(){
   string tbetween = s.substr(openpos+1, s.length()-openpos-2);
   cout<<token<<endl;
   cout<<tbetween<<endl;
+
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5,57 +5,32 @@
 #include<algorithm>
 
 //tokenize select query for processing
-//tokenize select query for processing
 void tokenize_select(char query[]){
-    vector<string> token_vector;
-    string current_token = "";
-    bool in_quotes = false;
-
-    for(int i = 0; query[i] != '\0'; i++){
-        char c = query[i];
-
-        // If we hit a quote, toggle our "inside quotes" state and add the quote to the token
-        if(c == '"'){
-            in_quotes = !in_quotes;
-            current_token += c; 
-        }
-        // If we are NOT in quotes, treat spaces, commas, semicolons, and newlines as split points
-        else if(!in_quotes && (c == ' ' || c == ',' || c == ';' || c == '\n')){
-            if(!current_token.empty()){
-                token_vector.push_back(current_token);
-                current_token = "";
-            }
-        }
-        // Otherwise, just keep building the current word
-        else {
-            if(c != '\n') {
-                current_token += c;
-            }
-        }
-    }
+    char buffer[1024];
+    vector <string> token_vector;
     
-    // Catch the very last token if the string ended
-    if(!current_token.empty()){
-        token_vector.push_back(current_token);
+    strcpy(buffer, query);
+    
+    // Uses standard strtok, splitting strictly on spaces, commas, semicolons, and newlines
+    char *token = strtok(buffer, " ,;\n"); 
+    
+    while (token) {
+        string token_temp(token);
+        if(token_temp != " " && token_temp != "\n" ){
+            token_vector.push_back(token_temp);
+        }
+        token = strtok(NULL, " ,;\n"); 
     }
-
     process_select(token_vector);
 }
 
 //tokenize create query for processing
 void tokenize_create(char query[]){
-    // CREATE TABLE [IF NOT EXISTS] <tablename> (<column1> <datatype>, <column2> <datatype>, PRIMARY KEY(<column1>));
-
-    /*
-    * implementation1
-    CREATE TABLE <tablename> (<column1> <datatype>, <column2> <datatype>);
-    */
     char buffer[1024];
     vector <string> token_vector;
 
     strcpy(buffer, query);
     
-    // FIX: Added \n here as well so CREATE queries don't suffer from the same newline bug
     char *token = strtok(buffer, " ,;\n");
     while (token) {
         string token_temp(token);
@@ -65,10 +40,6 @@ void tokenize_create(char query[]){
         }
         token = strtok(NULL, " ,;\n");
     }
-
-    // for(int i=0;i<token_vector.size();i++){
-    //     cout<<token_vector[i]<<endl;
-    // }
     cout<<endl;
 }
 
@@ -81,16 +52,13 @@ void get_query(){
     fgets(query,sizeof(char)*MAX_NAME,stdin);
     fgets(query,sizeof(char)*MAX_NAME,stdin);
 
-    //
     char buffer[1024];
     strcpy(buffer, query);
     
-    // FIX: Added \n here to ensure the first command word is caught cleanly
     char *token = strtok(buffer, " \n");
     if(token){
         string token_temp(token);
         if(token_temp != " " && token_temp != "\n"){
-            //cout<<"token:: "<<token<<endl;
             if(token_temp == "select"){
                 tokenize_select(query);
             }else if(token_temp == "create"){
@@ -98,9 +66,6 @@ void get_query(){
             }
         }
     }
-
-
-    //printf("\nquery:: %s\n",query);
 }
 
 void parse_create(){
@@ -114,5 +79,4 @@ void parse_create(){
   string tbetween = s.substr(openpos+1, s.length()-openpos-2);
   cout<<token<<endl;
   cout<<tbetween<<endl;
-
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,24 +1,44 @@
-
 #include "parser.h"
 #include "display.h"
 #include<cstring>
 #include<iostream>
+#include<algorithm>
 
 //tokenize select query for processing
+//tokenize select query for processing
 void tokenize_select(char query[]){
-    // break the query into tokens
-    char buffer[1024];
-    vector <string> token_vector;
-    //vector <string> temp;
-    strcpy(buffer, query);
-    char *token = strtok(buffer, " ,;");
-    while (token) {
-        string token_temp(token);
-        if(token_temp != " " && token_temp != "\n" ){
-            token_vector.push_back(token_temp);
+    vector<string> token_vector;
+    string current_token = "";
+    bool in_quotes = false;
+
+    for(int i = 0; query[i] != '\0'; i++){
+        char c = query[i];
+
+        // If we hit a quote, toggle our "inside quotes" state and add the quote to the token
+        if(c == '"'){
+            in_quotes = !in_quotes;
+            current_token += c; 
         }
-        token = strtok(NULL, " ,;");
+        // If we are NOT in quotes, treat spaces, commas, semicolons, and newlines as split points
+        else if(!in_quotes && (c == ' ' || c == ',' || c == ';' || c == '\n')){
+            if(!current_token.empty()){
+                token_vector.push_back(current_token);
+                current_token = "";
+            }
+        }
+        // Otherwise, just keep building the current word
+        else {
+            if(c != '\n') {
+                current_token += c;
+            }
+        }
     }
+    
+    // Catch the very last token if the string ended
+    if(!current_token.empty()){
+        token_vector.push_back(current_token);
+    }
+
     process_select(token_vector);
 }
 
@@ -34,14 +54,16 @@ void tokenize_create(char query[]){
     vector <string> token_vector;
 
     strcpy(buffer, query);
-    char *token = strtok(buffer, " ,;");
+    
+    // FIX: Added \n here as well so CREATE queries don't suffer from the same newline bug
+    char *token = strtok(buffer, " ,;\n");
     while (token) {
         string token_temp(token);
         if(token_temp != " " && token_temp != "\n" ){
           std::transform(token_temp.begin(), token_temp.end(), token_temp.begin(), ::tolower);
             token_vector.push_back(token_temp);
         }
-        token = strtok(NULL, " ,;");
+        token = strtok(NULL, " ,;\n");
     }
 
     // for(int i=0;i<token_vector.size();i++){
@@ -62,7 +84,9 @@ void get_query(){
     //
     char buffer[1024];
     strcpy(buffer, query);
-    char *token = strtok(buffer, " ");
+    
+    // FIX: Added \n here to ensure the first command word is caught cleanly
+    char *token = strtok(buffer, " \n");
     if(token){
         string token_temp(token);
         if(token_temp != " " && token_temp != "\n"){

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -1,8 +1,15 @@
-
 #include "where.h"
 #include "BPtree.h"
 
 void select_particular_query(std::string table_name, std::string col_to_search, std::string col_value,std::map<std::string, int> &display_col_list){
+    
+    // --- TRACK QUOTES ---
+    bool has_quotes = false;
+    if (col_value.length() >= 2 && col_value.front() == '"' && col_value.back() == '"') {
+        col_value = col_value.substr(1, col_value.length() - 2);
+        has_quotes = true;
+    }
+
     //process the particular query
     char *tab = (char*)malloc(sizeof(char)*MAX_NAME);
     strcpy(tab, table_name.c_str());
@@ -20,10 +27,8 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             if(fp){
                 display_col_list.clear();
                 fread(temp,1,sizeof(table),fp);
-                //cout<<"temp count:: "<<temp->count<<endl;
                 for(int i = 0; i < temp->count; i++){
                     std::string temp_str(temp->col[i].col_name);
-                    //cout<<"temp: "<<temp_str<<endl;
                     display_col_list.insert(make_pair(temp_str,0));
                 }
             }else{
@@ -32,25 +37,19 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             }
             std::map <std::string, int> :: iterator it;
             for(it = display_col_list.begin(); it != display_col_list.end(); it++){
-                //cout<<"col attributes::"<<it->first<<endl;
             }
         }
         //
         if(display_col_list.find("all_columns_set") == display_col_list.end()){
-            //printf("verifying columns\n");
             table *input;
             FILE *fpall = open_file(tab, const_cast<char*>("r"));
             input = (table*)malloc(sizeof(table));
 			if(fpall){
-                //cout<<"fp not null\n";
 				fread(input, sizeof(table), 1, fpall);
-                //cout<<"inp count:: "<<input->count<<endl;
 				for(int k = 0; k < input->count; k++){
 					std::string temp_str(input->col[k].col_name);
-                    //cout<<"temp_str:: "<<temp_str<<endl;
 					std::map <std::string, int>::iterator it = display_col_list.find(temp_str);
 					if(it != display_col_list.end()){
-                        //cout<<"it_first::"<<it->first<<endl;
 						it->second = 1;
 					}
 				}
@@ -78,7 +77,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             int ret=0;
             table *temp2 = (table*)malloc(sizeof(table));
             fread(temp2, sizeof(table), 1, fpall2);
-            //cout<<"temp2 count:: "<<temp2->count<<endl;
             if(strcmp(temp2->col[0].col_name,col_to_search.c_str()) == 0){
                 //primary key, use btree for searching
                 if(temp2->col[0].type == INT){
@@ -111,6 +109,13 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                        free(str1);
                    }
                }else if(temp2->col[0].type == VARCHAR){
+                   
+                   // --- ENFORCE QUOTES FOR B-TREE VARCHAR ---
+                   if (!has_quotes) {
+                       printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
+                       return;
+                   }
+
                    strcpy(pri_char,col_value.c_str());
                    void *arr[MAX_NAME];
                    arr[0] = (char*)malloc(sizeof(char)*MAX_NAME);
@@ -120,7 +125,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                        printf("\nkey %s don't exist !!!\n", pri_char);
                    }
                    else{
-                       //print the details of the particular row;
                        FILE *fpz;
                        char *str1;
                        str1 = (char*)malloc(sizeof(char)*MAX_PATH);
@@ -129,7 +133,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                        printf("\n------------------------------------\n");
                        for(int j = 0; j < temp2->count; j++){
                            std::string temp_str(temp2->col[j].col_name);
-                         //  if(display_col_list.find(temp_str) != display_col_list.end()){
                                if(temp2->col[j].type == INT){
                                    fread(&c, 1, sizeof(int), fpz);
                                    if(display_col_list.find(temp_str) != display_col_list.end())
@@ -140,7 +143,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                                    if(display_col_list.find(temp_str) != display_col_list.end())
                                    std::cout << d << setw(20);
                                }
-                         //  }
                        }
                        printf("\n-------------------------------------\n");
                        fclose(fpz);
@@ -149,12 +151,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                }
             }else{
                 //brute force search
-                //column entered not a primary key
-                /*
-                    * identify the column no.
-                    * fseek for column in file file%d.dat
-                    * check if the entry matches
-                */
                 int col_number = 1;
                 int col_type = 0;
                 int flag = 0;
@@ -166,7 +162,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                         col_number = i + 1;
                         col_type = tempbf->col[i].type;
                         flag = 1;
-                        //cout<<"col_number,col_type::"<<col_number<<", "<<col_type<<endl;
                         break;
                     }
                 }
@@ -174,33 +169,33 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                     printf("\ncolumn doesn't exist\nexiting...\n\n");
                     return ;
                 }else{
+                    
+                    // --- ENFORCE QUOTES FOR BRUTE FORCE VARCHAR ---
+                    if (col_type == VARCHAR && !has_quotes) {
+                        printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
+                        return;
+                    }
+
                     //search for entry;
                     flag = 0;
                     int c;
                     char d[MAX_NAME];
-                    //cout<<"C........"<<c<<endl;
                     for(int i=0;i<tempbf->rec_count;i++){
                             FILE *fpr;
                             char *str;
                             str=(char*)malloc(sizeof(char)*MAX_PATH);
                             sprintf(str,"table/%s/file%d.dat",tab,i);
-                            //cout<<str<<endl;
                             fpr=fopen(str,"r");
                             for(int j = 0; j < col_number; j++){
-                                //make it more efficient;
                                     if(tempbf->col[j].type == INT){
                                         fread(&c,1,sizeof(int),fpr);
-                                        //cout<<"c::"<<c<<endl;
                                     }else if(tempbf->col[j].type == VARCHAR){
                                         fread(d,1,sizeof(char)*MAX_NAME,fpr);
-                                        //cout<<"d:: "<<d<<endl;
                                     }
                             }
                             if(col_type == INT){
                                 int col_int_value = atoi( col_value.c_str());
                                 if(col_int_value == c){
-                                    //display the requried fields
-                                    //printf("col_type is int");
                                     int c1;
                                     char d1[MAX_NAME];
                                     fclose(fpr);
@@ -223,9 +218,7 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                                     flag = 1;
                                 }
                             }else if(col_type == VARCHAR){
-                                //cout<<"d,col_value:: "<<d<<" ,"<<col_value.c_str()<<endl;
                                 if(strcmp(d,col_value.c_str()) == 0){
-                                    //printf("col_type varchar");
                                     int c1;
                                     char d1[MAX_NAME];
                                     fclose(fpr);

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -20,6 +20,8 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
         */
         FILE *fp = open_file(tab, const_cast<char*>("r"));
         if(display_col_list.find("all_columns_set") != display_col_list.end()){
+            //printf("all columns set *\n");
+            //select contains * , insert all columns into display_col_list;
             table *temp;
             temp = (table*)malloc(sizeof(table));
             if(fp){
@@ -37,6 +39,7 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             for(it = display_col_list.begin(); it != display_col_list.end(); it++){
             }
         }
+        //
         if(display_col_list.find("all_columns_set") == display_col_list.end()){
             table *input;
             FILE *fpall = open_file(tab, const_cast<char*>("r"));
@@ -53,6 +56,7 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
 				std::map <std::string, int> :: iterator it = display_col_list.begin();
 				for(it = display_col_list.begin(); it != display_col_list.end(); it++){
 					if(it->second == 0){
+						//column dont exist in table, query error
 						printf("\nerror\n");
 						std::cout << it->first << " is not a valid column for table " << input->name << "\n";
 						return;
@@ -74,6 +78,7 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             table *temp2 = (table*)malloc(sizeof(table));
             fread(temp2, sizeof(table), 1, fpall2);
             if(strcmp(temp2->col[0].col_name,col_to_search.c_str()) == 0){
+                //primary key, use btree for searching
                 if(temp2->col[0].type == INT){
                     pri_int = atoi( col_value.c_str());
                     ret = mytree.get_record(pri_int);
@@ -104,10 +109,13 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                        free(str1);
                    }
                }else if(temp2->col[0].type == VARCHAR){
+                   
+                   // --- ENFORCE QUOTES FOR B-TREE VARCHAR ---
                    if (!has_quotes) {
                        printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
                        return;
                    }
+
                    strcpy(pri_char,col_value.c_str());
                    void *arr[MAX_NAME];
                    arr[0] = (char*)malloc(sizeof(char)*MAX_NAME);
@@ -142,6 +150,7 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                    }
                }
             }else{
+                //brute force search
                 int col_number = 1;
                 int col_type = 0;
                 int flag = 0;
@@ -160,10 +169,14 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                     printf("\ncolumn doesn't exist\nexiting...\n\n");
                     return ;
                 }else{
+                    
+                    // --- ENFORCE QUOTES FOR BRUTE FORCE VARCHAR ---
                     if (col_type == VARCHAR && !has_quotes) {
                         printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
                         return;
                     }
+
+                    //search for entry;
                     flag = 0;
                     int c;
                     char d[MAX_NAME];

--- a/src/where.cpp
+++ b/src/where.cpp
@@ -20,8 +20,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
         */
         FILE *fp = open_file(tab, const_cast<char*>("r"));
         if(display_col_list.find("all_columns_set") != display_col_list.end()){
-            //printf("all columns set *\n");
-            //select contains * , insert all columns into display_col_list;
             table *temp;
             temp = (table*)malloc(sizeof(table));
             if(fp){
@@ -39,7 +37,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             for(it = display_col_list.begin(); it != display_col_list.end(); it++){
             }
         }
-        //
         if(display_col_list.find("all_columns_set") == display_col_list.end()){
             table *input;
             FILE *fpall = open_file(tab, const_cast<char*>("r"));
@@ -56,7 +53,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
 				std::map <std::string, int> :: iterator it = display_col_list.begin();
 				for(it = display_col_list.begin(); it != display_col_list.end(); it++){
 					if(it->second == 0){
-						//column dont exist in table, query error
 						printf("\nerror\n");
 						std::cout << it->first << " is not a valid column for table " << input->name << "\n";
 						return;
@@ -78,7 +74,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
             table *temp2 = (table*)malloc(sizeof(table));
             fread(temp2, sizeof(table), 1, fpall2);
             if(strcmp(temp2->col[0].col_name,col_to_search.c_str()) == 0){
-                //primary key, use btree for searching
                 if(temp2->col[0].type == INT){
                     pri_int = atoi( col_value.c_str());
                     ret = mytree.get_record(pri_int);
@@ -109,13 +104,10 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                        free(str1);
                    }
                }else if(temp2->col[0].type == VARCHAR){
-                   
-                   // --- ENFORCE QUOTES FOR B-TREE VARCHAR ---
                    if (!has_quotes) {
                        printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
                        return;
                    }
-
                    strcpy(pri_char,col_value.c_str());
                    void *arr[MAX_NAME];
                    arr[0] = (char*)malloc(sizeof(char)*MAX_NAME);
@@ -150,7 +142,6 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                    }
                }
             }else{
-                //brute force search
                 int col_number = 1;
                 int col_type = 0;
                 int flag = 0;
@@ -169,14 +160,10 @@ void select_particular_query(std::string table_name, std::string col_to_search, 
                     printf("\ncolumn doesn't exist\nexiting...\n\n");
                     return ;
                 }else{
-                    
-                    // --- ENFORCE QUOTES FOR BRUTE FORCE VARCHAR ---
                     if (col_type == VARCHAR && !has_quotes) {
                         printf("\nSyntax error: String literals must be enclosed in double quotes (\"\").\n\n");
                         return;
                     }
-
-                    //search for entry;
                     flag = 0;
                     int c;
                     char d[MAX_NAME];


### PR DESCRIPTION
## 📝 Description
This PR resolves Issue #4 by upgrading our custom SQL parser to properly handle and strictly enforce standard MySQL string formatting in `WHERE` clauses.

Previously, the parser relied on `strtok` which blindly split queries on spaces, breaking string literals that contained spaces. Furthermore, it did not strictly enforce quotation marks for `VARCHAR` data.

## 🛠️ Changes Made
* **`src/parser.cpp`**: Replaced the `strtok` tokenization with a custom, state-aware character loop. The parser now tracks an `in_quotes` state, allowing it to preserve spaces inside string literals (e.g., `"John Doe"`).
* **`src/where.cpp`**: Added strict syntax enforcement for string searches. 
  * `VARCHAR` column searches now explicitly require double quotes (`" "`).
  * Bare strings (e.g., `Aditya`) and single quotes (e.g., `'Aditya'`) are now actively rejected with a clear syntax error.
  * Standard integer searches remain unaffected.

## 🧪 How to Test
1. Checkout this branch and run `make clean && make`.
2. Boot the engine: `./miniDB -u test -p` (password is `pass`)
3. Create a test table: `CREATE TABLE test (id 1 5, name 2 50)`
4. Insert a record: `INSERT INTO test (1, "John Doe")`
5. Test a valid query: `SELECT * FROM test WHERE name = "John Doe"` *(Should successfully return the record)*
6. Test a bare string query: `SELECT * FROM test WHERE name = John` *(Should throw syntax error)*
7. Test a single quote query: `SELECT * FROM test WHERE name = 'John Doe'` *(Should throw syntax error)*

Closes #4