### PR TITLE
New Model Design : Add page-based storage foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 table/*
 !table/table_list
+
+# Local planning/design notes for issue work
+Documentation/

--- a/include/data_page.h
+++ b/include/data_page.h
@@ -1,0 +1,54 @@
+#ifndef DATA_PAGE_H
+#define DATA_PAGE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "storage_types.h"
+
+/*
+ * DataPage is the next layer above DiskManager.
+ *
+ * Before:
+ * - the old code wrote one row directly into one separate file
+ *
+ * After:
+ * - many rows are packed into one page
+ * - each inserted row gets a slot_id inside that page
+ *
+ * Layman version:
+ * - DiskManager handles the notebook
+ * - DataPage decides where each line is written on a page of that notebook
+ */
+class DataPage {
+  public:
+    DataPage();
+
+    void initialize(uint32_t page_id);
+
+    bool load_from_buffer(const char* buffer, std::size_t buffer_size);
+    const char* data() const;
+    char* data();
+    std::size_t size() const;
+
+    PageHeader header() const;
+    bool write_header(const PageHeader& header);
+
+    uint16_t free_space() const;
+    uint16_t slot_count() const;
+    bool can_store(std::size_t tuple_size) const;
+
+    bool insert_tuple(const char* tuple_data,
+                      uint16_t tuple_size,
+                      uint16_t& slot_id_out);
+    bool read_tuple(uint16_t slot_id, std::vector<char>& tuple_out) const;
+
+  private:
+    std::vector<char> bytes_;
+
+    SlotEntry read_slot(uint16_t slot_id) const;
+    void write_slot(uint16_t slot_id, const SlotEntry& entry);
+};
+
+#endif

--- a/include/disk_manager.h
+++ b/include/disk_manager.h
@@ -1,0 +1,58 @@
+#ifndef DISK_MANAGER_H
+#define DISK_MANAGER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <string>
+
+#include "storage_types.h"
+
+/*
+ * DiskManager is the raw page I/O layer.
+ *
+ * It should only know:
+ * - where the file is
+ * - how large a page is
+ * - how to allocate, read, and write a page
+ *
+ * It should not know:
+ * - SQL
+ * - tuples
+ * - indexes
+ * - query execution
+ *
+ * That separation is intentional because this layer is the base for
+ * both table pages and future index pages.
+ *
+ * Layman version:
+ * - this class is just the page file handler
+ * - it should only know how to store and fetch page-sized blocks
+ */
+class DiskManager {
+  public:
+    explicit DiskManager(const std::string& path,
+                         std::size_t page_size = STORAGE_PAGE_SIZE);
+    ~DiskManager();
+
+    bool open_or_create();
+    void close();
+
+    uint32_t allocate_page();
+    bool read_page(uint32_t page_id, char* buffer);
+    bool write_page(uint32_t page_id, const char* buffer);
+
+    uint32_t page_count();
+    std::size_t page_size() const;
+    bool is_open() const;
+
+  private:
+    std::string path_;
+    std::size_t page_size_;
+    std::fstream file_;
+
+    uint32_t page_count_unchecked();
+    std::streamoff page_offset(uint32_t page_id) const;
+};
+
+#endif

--- a/include/storage_types.h
+++ b/include/storage_types.h
@@ -1,0 +1,111 @@
+#ifndef STORAGE_TYPES_H
+#define STORAGE_TYPES_H
+
+#include <cstddef>
+#include <cstdint>
+
+/*
+ * Storage foundation for the redesigned engine.
+ *
+ * Before:
+ * - one inserted row was effectively tracked as fileN.dat
+ * - the index pointed to a record number that later opened a row file
+ *
+ * After:
+ * - data is meant to live inside fixed-size pages
+ * - rows are identified by RID(page_id, slot_id)
+ * - higher layers will fetch a page first, then a tuple inside that page
+ *
+ * Layman version:
+ * - before, one row behaved like one small file
+ * - after, many rows live together inside one bigger block called a page
+ */
+
+static const std::size_t STORAGE_PAGE_SIZE = 4096;
+static const uint32_t INVALID_PAGE_ID = UINT32_MAX;
+static const uint16_t INVALID_SLOT_ID = UINT16_MAX;
+
+enum PageType {
+    PAGE_TYPE_INVALID = 0,
+    PAGE_TYPE_TABLE_DATA = 1,
+    PAGE_TYPE_BTREE_INTERNAL = 2,
+    PAGE_TYPE_BTREE_LEAF = 3
+};
+
+/*
+ * RID is the new logical row address.
+ *
+ * Why this replaces record_number:
+ * - it matches page-based storage
+ * - it is what a B+ Tree should point to later
+ * - it avoids coupling lookup logic to file names like file7.dat
+ *
+ * Layman version:
+ * - before, we said "open row file number 7"
+ * - after, we say "go to page X and slot Y"
+ */
+struct RID {
+    uint32_t page_id;
+    uint16_t slot_id;
+
+    RID()
+        : page_id(INVALID_PAGE_ID), slot_id(INVALID_SLOT_ID) {
+    }
+
+    RID(uint32_t page, uint16_t slot)
+        : page_id(page), slot_id(slot) {
+    }
+};
+
+/*
+ * Each slot entry tells us where one tuple lives inside a page.
+ *
+ * offset -> starting byte of the tuple
+ * length -> tuple size in bytes
+ *
+ * Layman version:
+ * - this is a small label telling us where a row starts and how big it is
+ */
+struct SlotEntry {
+    uint16_t offset;
+    uint16_t length;
+
+    SlotEntry()
+        : offset(0), length(0) {
+    }
+
+    SlotEntry(uint16_t tuple_offset, uint16_t tuple_length)
+        : offset(tuple_offset), length(tuple_length) {
+    }
+};
+
+/*
+ * Header placed at the beginning of each page.
+ *
+ * free_start grows forward as slot entries are added.
+ * free_end grows backward as tuple bytes are inserted.
+ * The free space of the page always stays between them.
+ *
+ * Layman version:
+ * - the header is the control panel of the page
+ * - it tells us how full the page is and where the next row can go
+ */
+struct PageHeader {
+    uint32_t page_id;
+    uint16_t slot_count;
+    uint16_t free_start;
+    uint16_t free_end;
+    uint16_t page_type;
+    uint32_t next_page_id;
+
+    PageHeader()
+        : page_id(INVALID_PAGE_ID),
+          slot_count(0),
+          free_start(sizeof(PageHeader)),
+          free_end(static_cast<uint16_t>(STORAGE_PAGE_SIZE)),
+          page_type(PAGE_TYPE_INVALID),
+          next_page_id(INVALID_PAGE_ID) {
+    }
+};
+
+#endif

--- a/include/storage_types.h
+++ b/include/storage_types.h
@@ -33,7 +33,7 @@ enum PageType {
 };
 
 /*
- * RID is the new logical row address.
+ * RID (Record ID) is the new logical row address. tuple -- > [ page_id , slot_id ] 
  *
  * Why this replaces record_number:
  * - it matches page-based storage

--- a/include/tuple_serializer.h
+++ b/include/tuple_serializer.h
@@ -1,0 +1,85 @@
+#ifndef TUPLE_SERIALIZER_H
+#define TUPLE_SERIALIZER_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/*
+ * Tuple serialization is the bridge between "row values" and "page bytes".
+ *
+ * Before:
+ * - DataPage could only store raw bytes
+ * - there was no clean way to convert actual row values into bytes
+ *
+ * After:
+ * - rows can be packed into a consistent byte format
+ * - the same format can later be unpacked back into values
+ *
+ * Layman version:
+ * - this is the packing and unpacking rule for a row
+ * - it tells us how to turn values into bytes and bytes back into values
+ */
+
+enum StorageColumnType {
+    STORAGE_COLUMN_INT = 1,
+    STORAGE_COLUMN_VARCHAR = 2
+};
+
+/*
+ * ColumnSchema describes one column of a row for storage purposes.
+ *
+ * name       -> column name
+ * type       -> integer or varchar
+ * max_length -> varchar limit for V1, ignored for integer
+ */
+struct ColumnSchema {
+    std::string name;
+    uint16_t type;
+    uint16_t max_length;
+
+    ColumnSchema()
+        : name(), type(STORAGE_COLUMN_INT), max_length(0) {
+    }
+
+    ColumnSchema(const std::string& column_name,
+                 uint16_t column_type,
+                 uint16_t column_max_length = 0)
+        : name(column_name),
+          type(column_type),
+          max_length(column_max_length) {
+    }
+};
+
+/*
+ * TupleValue stores one row value in memory before serialization or after
+ * deserialization.
+ *
+ * Layman version:
+ * - this is one field value before it gets packed into bytes
+ */
+struct TupleValue {
+    uint16_t type;
+    int32_t int_value;
+    std::string string_value;
+
+    TupleValue()
+        : type(STORAGE_COLUMN_INT), int_value(0), string_value() {
+    }
+
+    static TupleValue FromInt(int32_t value);
+    static TupleValue FromVarchar(const std::string& value);
+};
+
+class TupleSerializer {
+  public:
+    static bool serialize(const std::vector<ColumnSchema>& schema,
+                          const std::vector<TupleValue>& values,
+                          std::vector<char>& tuple_out);
+
+    static bool deserialize(const std::vector<ColumnSchema>& schema,
+                            const std::vector<char>& tuple_bytes,
+                            std::vector<TupleValue>& values_out);
+};
+
+#endif

--- a/src/data_page.cpp
+++ b/src/data_page.cpp
@@ -1,0 +1,144 @@
+#include "data_page.h"
+
+#include <cstring>
+
+namespace {
+const std::size_t SLOT_ENTRY_SIZE = sizeof(SlotEntry);
+}
+
+/*
+ * This file turns a raw 4 KB block into a usable table-data page.
+ *
+ * Before:
+ * - storage logic had no concept of "multiple rows inside one page"
+ *
+ * After:
+ * - one page has a header, slot directory, free space, and tuple area
+ * - tuples are inserted from the back, slots are added from the front
+ *
+ * Layman version:
+ * - this is the packing logic inside one page
+ * - it decides where each row sits inside the block
+ */
+
+DataPage::DataPage()
+    : bytes_(STORAGE_PAGE_SIZE, 0) {
+}
+
+void DataPage::initialize(uint32_t page_id) {
+    std::fill(bytes_.begin(), bytes_.end(), 0);
+
+    PageHeader header;
+    header.page_id = page_id;
+    header.page_type = PAGE_TYPE_TABLE_DATA;
+    write_header(header);
+}
+
+bool DataPage::load_from_buffer(const char* buffer, std::size_t buffer_size) {
+    if (buffer == NULL || buffer_size != bytes_.size()) {
+        return false;
+    }
+
+    std::memcpy(&bytes_[0], buffer, bytes_.size());
+    return true;
+}
+
+const char* DataPage::data() const {
+    return &bytes_[0];
+}
+
+char* DataPage::data() {
+    return &bytes_[0];
+}
+
+std::size_t DataPage::size() const {
+    return bytes_.size();
+}
+
+PageHeader DataPage::header() const {
+    PageHeader header;
+    std::memcpy(&header, &bytes_[0], sizeof(PageHeader));
+    return header;
+}
+
+bool DataPage::write_header(const PageHeader& header) {
+    if (sizeof(PageHeader) > bytes_.size()) {
+        return false;
+    }
+
+    std::memcpy(&bytes_[0], &header, sizeof(PageHeader));
+    return true;
+}
+
+uint16_t DataPage::free_space() const {
+    const PageHeader page_header = header();
+    if (page_header.free_end < page_header.free_start) {
+        return 0;
+    }
+
+    return static_cast<uint16_t>(page_header.free_end - page_header.free_start);
+}
+
+uint16_t DataPage::slot_count() const {
+    return header().slot_count;
+}
+
+bool DataPage::can_store(std::size_t tuple_size) const {
+    return free_space() >= tuple_size + SLOT_ENTRY_SIZE;
+}
+
+bool DataPage::insert_tuple(const char* tuple_data,
+                            uint16_t tuple_size,
+                            uint16_t& slot_id_out) {
+    if (tuple_data == NULL || tuple_size == 0 || !can_store(tuple_size)) {
+        return false;
+    }
+
+    PageHeader page_header = header();
+
+    const uint16_t tuple_offset =
+        static_cast<uint16_t>(page_header.free_end - tuple_size);
+    std::memcpy(&bytes_[tuple_offset], tuple_data, tuple_size);
+
+    const uint16_t new_slot_id = page_header.slot_count;
+    write_slot(new_slot_id, SlotEntry(tuple_offset, tuple_size));
+
+    page_header.slot_count =
+        static_cast<uint16_t>(page_header.slot_count + 1);
+    page_header.free_start = static_cast<uint16_t>(
+        sizeof(PageHeader) + page_header.slot_count * SLOT_ENTRY_SIZE);
+    page_header.free_end = tuple_offset;
+    write_header(page_header);
+
+    slot_id_out = new_slot_id;
+    return true;
+}
+
+bool DataPage::read_tuple(uint16_t slot_id, std::vector<char>& tuple_out) const {
+    if (slot_id >= slot_count()) {
+        return false;
+    }
+
+    const SlotEntry entry = read_slot(slot_id);
+    if (entry.length == 0) {
+        return false;
+    }
+
+    tuple_out.assign(entry.length, 0);
+    std::memcpy(&tuple_out[0], &bytes_[entry.offset], entry.length);
+    return true;
+}
+
+SlotEntry DataPage::read_slot(uint16_t slot_id) const {
+    SlotEntry entry;
+    const std::size_t slot_offset =
+        sizeof(PageHeader) + static_cast<std::size_t>(slot_id) * SLOT_ENTRY_SIZE;
+    std::memcpy(&entry, &bytes_[slot_offset], SLOT_ENTRY_SIZE);
+    return entry;
+}
+
+void DataPage::write_slot(uint16_t slot_id, const SlotEntry& entry) {
+    const std::size_t slot_offset =
+        sizeof(PageHeader) + static_cast<std::size_t>(slot_id) * SLOT_ENTRY_SIZE;
+    std::memcpy(&bytes_[slot_offset], &entry, SLOT_ENTRY_SIZE);
+}

--- a/src/disk_manager.cpp
+++ b/src/disk_manager.cpp
@@ -1,0 +1,141 @@
+#include "disk_manager.h"
+
+#include <vector>
+
+/*
+ * This file implements the new page-based disk access path.
+ *
+ * Before:
+ * - old code directly opened metadata files and per-row files
+ *
+ * After:
+ * - one storage file can contain many fixed-size pages
+ * - higher layers will ask for page_id instead of fileN.dat
+ *
+ * Layman version:
+ * - before, storage was scattered across many small files
+ * - after, storage is organized into equal-sized blocks inside one file
+ */
+
+DiskManager::DiskManager(const std::string& path, std::size_t page_size)
+    : path_(path), page_size_(page_size) {
+}
+
+DiskManager::~DiskManager() {
+    close();
+}
+
+bool DiskManager::open_or_create() {
+    close();
+
+    // Try opening an existing database file first.
+    file_.open(path_.c_str(), std::ios::in | std::ios::out | std::ios::binary);
+    if (file_.is_open()) {
+        return true;
+    }
+
+    // If it does not exist yet, create an empty file and reopen it for r/w.
+    std::ofstream create_file(path_.c_str(), std::ios::out | std::ios::binary);
+    if (!create_file.is_open()) {
+        return false;
+    }
+    create_file.close();
+
+    file_.open(path_.c_str(), std::ios::in | std::ios::out | std::ios::binary);
+    return file_.is_open();
+}
+
+void DiskManager::close() {
+    if (file_.is_open()) {
+        file_.close();
+    }
+}
+
+uint32_t DiskManager::allocate_page() {
+    if (!is_open()) {
+        return INVALID_PAGE_ID;
+    }
+
+    // New pages are appended at the end of the file.
+    // page_id is therefore just the current number of stored pages.
+    // Layman version: a new page is simply added after the last existing page.
+    const uint32_t new_page_id = page_count_unchecked();
+    std::vector<char> empty_page(page_size_, 0);
+
+    file_.clear();
+    file_.seekp(page_offset(new_page_id), std::ios::beg);
+    file_.write(&empty_page[0], static_cast<std::streamsize>(empty_page.size()));
+    file_.flush();
+
+    if (!file_) {
+        return INVALID_PAGE_ID;
+    }
+
+    return new_page_id;
+}
+
+bool DiskManager::read_page(uint32_t page_id, char* buffer) {
+    if (!is_open() || buffer == NULL || page_id >= page_count_unchecked()) {
+        return false;
+    }
+
+    // A page lives at byte offset: page_id * page_size.
+    // Layman version: page 0 starts at byte 0, page 1 starts after one page,
+    // page 2 after two pages, and so on.
+    file_.clear();
+    file_.seekg(page_offset(page_id), std::ios::beg);
+    file_.read(buffer, static_cast<std::streamsize>(page_size_));
+
+    return file_.good();
+}
+
+bool DiskManager::write_page(uint32_t page_id, const char* buffer) {
+    if (!is_open() || buffer == NULL || page_id >= page_count_unchecked()) {
+        return false;
+    }
+
+    // Overwrite exactly one fixed-size page at its computed offset.
+    // Layman version: replace one block, not the whole file.
+    file_.clear();
+    file_.seekp(page_offset(page_id), std::ios::beg);
+    file_.write(buffer, static_cast<std::streamsize>(page_size_));
+    file_.flush();
+
+    return file_.good();
+}
+
+uint32_t DiskManager::page_count() {
+    if (!is_open()) {
+        return 0;
+    }
+
+    return page_count_unchecked();
+}
+
+std::size_t DiskManager::page_size() const {
+    return page_size_;
+}
+
+bool DiskManager::is_open() const {
+    return file_.is_open();
+}
+
+uint32_t DiskManager::page_count_unchecked() {
+    file_.clear();
+    file_.seekg(0, std::ios::end);
+    const std::streamoff bytes = file_.tellg();
+
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    return static_cast<uint32_t>(bytes / static_cast<std::streamoff>(page_size_));
+}
+
+std::streamoff DiskManager::page_offset(uint32_t page_id) const {
+    // This is the key rule of page-based storage:
+    // page N starts at N * page_size bytes inside the file.
+    // Layman version: every page has a fixed seat number inside the file.
+    return static_cast<std::streamoff>(page_id) *
+           static_cast<std::streamoff>(page_size_);
+}

--- a/src/tuple_serializer.cpp
+++ b/src/tuple_serializer.cpp
@@ -1,0 +1,134 @@
+#include "tuple_serializer.h"
+
+#include <cstring>
+#include <limits>
+
+namespace {
+template <typename T>
+void append_value(std::vector<char>& out, const T& value) {
+    const char* start = reinterpret_cast<const char*>(&value);
+    out.insert(out.end(), start, start + sizeof(T));
+}
+
+template <typename T>
+bool read_value(const std::vector<char>& bytes,
+                std::size_t offset,
+                T& value_out) {
+    if (offset + sizeof(T) > bytes.size()) {
+        return false;
+    }
+
+    std::memcpy(&value_out, &bytes[offset], sizeof(T));
+    return true;
+}
+}  // namespace
+
+TupleValue TupleValue::FromInt(int32_t value) {
+    TupleValue tuple_value;
+    tuple_value.type = STORAGE_COLUMN_INT;
+    tuple_value.int_value = value;
+    return tuple_value;
+}
+
+TupleValue TupleValue::FromVarchar(const std::string& value) {
+    TupleValue tuple_value;
+    tuple_value.type = STORAGE_COLUMN_VARCHAR;
+    tuple_value.string_value = value;
+    return tuple_value;
+}
+
+bool TupleSerializer::serialize(const std::vector<ColumnSchema>& schema,
+                                const std::vector<TupleValue>& values,
+                                std::vector<char>& tuple_out) {
+    tuple_out.clear();
+
+    if (schema.size() != values.size()) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < schema.size(); ++i) {
+        const ColumnSchema& column = schema[i];
+        const TupleValue& value = values[i];
+
+        if (column.type != value.type) {
+            return false;
+        }
+
+        if (column.type == STORAGE_COLUMN_INT) {
+            append_value(tuple_out, value.int_value);
+            continue;
+        }
+
+        if (column.type == STORAGE_COLUMN_VARCHAR) {
+            if (value.string_value.size() >
+                static_cast<std::size_t>(column.max_length)) {
+                return false;
+            }
+
+            if (value.string_value.size() >
+                static_cast<std::size_t>(std::numeric_limits<uint16_t>::max())) {
+                return false;
+            }
+
+            const uint16_t string_length =
+                static_cast<uint16_t>(value.string_value.size());
+            append_value(tuple_out, string_length);
+            tuple_out.insert(tuple_out.end(),
+                             value.string_value.begin(),
+                             value.string_value.end());
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+bool TupleSerializer::deserialize(const std::vector<ColumnSchema>& schema,
+                                  const std::vector<char>& tuple_bytes,
+                                  std::vector<TupleValue>& values_out) {
+    values_out.clear();
+
+    std::size_t offset = 0;
+    for (std::size_t i = 0; i < schema.size(); ++i) {
+        const ColumnSchema& column = schema[i];
+
+        if (column.type == STORAGE_COLUMN_INT) {
+            int32_t int_value = 0;
+            if (!read_value(tuple_bytes, offset, int_value)) {
+                return false;
+            }
+
+            values_out.push_back(TupleValue::FromInt(int_value));
+            offset += sizeof(int32_t);
+            continue;
+        }
+
+        if (column.type == STORAGE_COLUMN_VARCHAR) {
+            uint16_t string_length = 0;
+            if (!read_value(tuple_bytes, offset, string_length)) {
+                return false;
+            }
+
+            offset += sizeof(uint16_t);
+            if (offset + string_length > tuple_bytes.size()) {
+                return false;
+            }
+
+            if (string_length > column.max_length) {
+                return false;
+            }
+
+            std::string string_value(&tuple_bytes[offset],
+                                     &tuple_bytes[offset] + string_length);
+            values_out.push_back(TupleValue::FromVarchar(string_value));
+            offset += string_length;
+            continue;
+        }
+
+        return false;
+    }
+
+    return offset == tuple_bytes.size();
+}


### PR DESCRIPTION
working on the new **storage model**.

### Before

- one row was treated like one separate file
- search logic could end up opening `file0.dat`, `file1.dat`, etc.

### After

- many rows will live inside one fixed-size **page**
- rows will be found using a proper address inside that page system

- data is grouped into fixed-size blocks
- one disk read can bring many rows
- later the buffer pool can cache pages
- later the B+ Tree can point to row locations properly

• RID means Record ID.

  Very simply:

  - it is the address of a row inside page-based storage
  - format: RID = (page_id, slot_id)

  Meaning:

  - page_id = which page the row is in
  - slot_id = which entry inside that page points to the row

  Why we need it:

  - before, old code used something like record_number -> fileN.dat
  - that only works with row-per-file style storage
  - now we want many rows inside one page
  - so we need a proper row address inside that page system

  Example:

  - suppose row "id=5, name=Penut" is stored in page 3
  - inside page 3, its slot entry is 1
  - then its RID is:

  (3, 1)

  Why this is important later:

  - B+ Tree should not point to file names
  - B+ Tree should point to RID
  - then search becomes:
      - find key in B+ Tree
      - get RID
      - open page
      - read row from slot

  Now what the code currently does:

  In /home/aryan-s/..DBMS/src/storage_types.h:

  - RID stores row location
  - SlotEntry stores where tuple bytes are inside a page
  - PageHeader stores page metadata like free space and slot count

  In /home/aryan-s/..DBMS/src/disk_manager.cpp:

  - we made the raw page file handler
  - it only knows:
      - open file
      - allocate page
      - read page
      - write page

  In /home/aryan-s/..DBMS/src/data_page.cpp:

  - we made one page usable
  - now one page can hold multiple rows
  - rows are inserted from the back
  - slot entries are added from the front
  - free space stays in the middle


  - add a DataPage layer for slotted-page tuple storage   -- > Understand Slotted page tuple  https://medium.com/@shakirraza4227/what-are-slotted-pages-a-simple-guide-to-how-databases-store-rows-6deeae86200c


 **This starts the move from row-per-file storage to page-based storage. It sets up the base needed for RID-
  based access and later B+ Tree and buffer pool integration.**








## Tuple Serilization : 


Tuple serialization means:

> converting a logical row into raw bytes so it can be stored inside a page

### Example row

```text
id = 10
name = "Aryan"
```

The database understands this as values.

But `DataPage` cannot store "idea-level values".
It can only store bytes.

So we must convert the row into bytes first.

### Layman version

Serialization means:

- take a normal row
- pack it into a byte format
- put that packed byte format into the page

Very simply:

Before:
- row is a set of values in memory

After:
- row becomes a byte packet ready to store

---

## 13. Why Do We Need Tuple Serialization?

We need it because `DataPage` works like this:

```cpp
bool insert_tuple(const char* tuple_data, uint16_t tuple_size, uint16_t& slot_id_out);
```

It accepts:

- a pointer to bytes
- the byte size

It does **not** accept:

- `int id`
- `std::string name`
- full row objects directly

So something must sit between:

```text
logical row values
```

and

```text
page byte storage
```

That "something" is tuple serialization.

### Why it matters later

Without serialization:

- we cannot store rows consistently
- we cannot read them back correctly
- we cannot compare rows reliably
- we cannot build clean scan and index logic

---

## 14. How Are We Going To Implement It?

We will make a small layer that:

1. takes row values
2. converts them to bytes
3. returns `std::vector<char>`

Later, another function will:

1. take stored bytes
2. decode them
3. rebuild the logical values

So we need two directions:

- **serialize**: values -> bytes
- **deserialize**: bytes -> values

### Simple V1 encoding rule

For now we can keep the first version simple:

- `INT` = 4 bytes
- `VARCHAR` = `2 bytes length + actual characters`

### Example

Row:

```text
id = 10
name = "Aryan"
```

Encoded idea:

```text
[10 as 4 bytes][5 as uint16_t][A][r][y][a][n]
```

Why this is good:

- integer size is fixed
- string length tells us how many characters to read
- no wasted fixed 50-byte string blocks

### Layman version

We are deciding a packing rule.

Like:

- first put the number
- then put the string length
- then put the actual string letters

If we always follow the same packing rule, we can always unpack it later too.
